### PR TITLE
Change typo3 required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"license": ["GPL-2.0+"],
 
 	"require": {
-		"typo3/cms-core": "7.6.0-8.99.99"
+		"typo3/cms-core": "7.6.0 - 8.99.99"
 	},
 	"replace": {
 		"introduction": "*"


### PR DESCRIPTION
Change target version.
I had an error: Skipped branch master, Could not parse version constraint 7.6.0-8.99.99: Invalid version string "7.6.0-8.99.99"